### PR TITLE
[#18] Feat: Text 컴포넌트 틀 구현, 툴바 아이콘에 컴포넌트 부착

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -149,7 +149,11 @@ const Canvas = () => {
   const insertLayer = useMutation(
     (
       { storage, setMyPresence },
-      layerType: LayerType.Ellipse | LayerType.Rectangle,
+      layerType:
+        | LayerType.Ellipse
+        | LayerType.Rectangle
+        | LayerType.Note
+        | LayerType.Text,
       position: Point
     ) => {
       const liveLayers = storage.get("layers");

--- a/src/components/LayerComponent.tsx
+++ b/src/components/LayerComponent.tsx
@@ -5,7 +5,8 @@ import Path from "./Path";
 import { CanvasMode, LayerType } from "@/lib/types";
 import { colorToCss } from "@/lib/utils";
 import Rectangle from "./Rectangle";
-import Sticker from "./Sticker";
+import Note from "./Note";
+import Text from "./Text";
 
 type Props = {
   id: string;
@@ -55,9 +56,18 @@ const LayerComponent = memo(
             selectionColor={selectionColor}
           />
         );
-      case LayerType.Sticker:
+      case LayerType.Text:
         return (
-          <Sticker
+          <Text
+            id={id}
+            layer={layer}
+            onPointerDown={onLayerPointerDown}
+            selectionColor={selectionColor}
+          />
+        );
+      case LayerType.Note:
+        return (
+          <Note
             id={id}
             layer={layer}
             onPointerDown={onLayerPointerDown}

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -1,14 +1,14 @@
-import { StickerLayer } from "@/lib/types";
+import { NoteLayer } from "@/lib/types";
 import { colorToCss } from "@/lib/utils";
 
 type Props = {
   id: string;
-  layer: StickerLayer;
+  layer: NoteLayer;
   onPointerDown: (e: React.PointerEvent, id: string) => void;
   selectionColor?: string;
 };
 
-export default function Sticker({
+export default function Note({
   layer,
   onPointerDown,
   id,

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -45,3 +45,5 @@ const Text = ({ layer, onPointerDown, id, selectionColor }: TextProps) => {
     </foreignObject>
   );
 };
+
+export default Text;

--- a/src/components/ToolsBar/index.tsx
+++ b/src/components/ToolsBar/index.tsx
@@ -46,7 +46,10 @@ export default function ToolsBar({
             onClick={() => setCanvasState({ mode: CanvasMode.Pencil })}
           />
           <TextButton
-            isActive={canvasState.mode === CanvasMode.Inserting}
+            isActive={
+              canvasState.mode === CanvasMode.Inserting &&
+              canvasState.layerType === LayerType.Text
+            }
             onClick={() =>
               setCanvasState({
                 mode: CanvasMode.Inserting,
@@ -81,12 +84,12 @@ export default function ToolsBar({
           <NoteButton
             isActive={
               canvasState.mode === CanvasMode.Inserting &&
-              canvasState.layerType === LayerType.Text
+              canvasState.layerType === LayerType.Note
             }
             onClick={() =>
               setCanvasState({
                 mode: CanvasMode.Inserting,
-                layerType: LayerType.Text,
+                layerType: LayerType.Note,
               })
             }
           />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,6 @@ export enum LayerType {
   Path,
   Text,
   Note,
-  Sticker,
 }
 
 export type Camera = {
@@ -23,7 +22,7 @@ export type Layer =
   | EllipseLayer
   | PathLayer
   | TextLayer
-  | StickerLayer;
+  | NoteLayer;
 
 export type RectangleLayer = {
   type: LayerType.Rectangle;
@@ -43,8 +42,8 @@ export type EllipseLayer = {
   fill: Color;
 };
 
-export type StickerLayer = {
-  type: LayerType.Sticker;
+export type NoteLayer = {
+  type: LayerType.Note;
   x: number;
   y: number;
   height: number;


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close #18 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [x] 버그 수정

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] Sticker 컴포넌트 Note로 이름 변경
- [x] Text 컴포넌트 틀 구현 (추가 수정 필요)
- [x] 툴바에서 버튼 활성화를 판단하는 로직에 있던 오류 수정

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

https://github.com/i-Dear/sync-d-frontend/assets/121740394/e54ec1b3-6971-4e4a-bd88-d52c7bf0f744

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

Sticker 컴포넌트는 추후 따봉, 이모티콘, 커스텀 사진 등 다양한 이미지들을 붙이는 컴포넌트 명으로 사용하는 게 좋을 것 같아 Note 컴포넌트로 이름을 변경하였습니다.

Text 컴포넌트는 현재 텍스트를 수정하는 로직이 구현되어 있지 않습니다.
