### PR TITLE
[#60] Feat: 캔버스 버튼 - Skip, Vote, 버튼 구현, 투표 및 완료 모달 구현,  Sync 퍼블리싱

### DIFF
--- a/src/components/CanvasToolBar/CanvasButton.tsx
+++ b/src/components/CanvasToolBar/CanvasButton.tsx
@@ -1,0 +1,16 @@
+import SkipButton from "./SkipButton";
+import SyncButton from "./SyncButton";
+import VoteButton from "./VoteButton";
+import { useMyPresence } from "~/liveblocks.config";
+
+const CanvasButton = () => {
+  return (
+    <div className="flex gap-[3rem]">
+      <SkipButton />
+      <VoteButton />
+      <SyncButton />
+    </div>
+  );
+};
+
+export default CanvasButton;

--- a/src/components/CanvasToolBar/SkipButton.tsx
+++ b/src/components/CanvasToolBar/SkipButton.tsx
@@ -1,0 +1,30 @@
+import useModalStore from "@/store/useModalStore";
+import { useMyPresence } from "~/liveblocks.config";
+
+const SKIPABLE_PROCESSES = [1, 2, 10, 11];
+
+const SkipButton = () => {
+  const { setModalType, setModalState } = useModalStore();
+  const [myPresence] = useMyPresence();
+  const { currentProcess } = myPresence;
+
+  const handleSkipButtonClick = () => {
+    setModalType("skip");
+    setModalState(true);
+  };
+
+  return (
+    <>
+      {SKIPABLE_PROCESSES.includes(currentProcess) ? (
+        <button
+          onClick={handleSkipButtonClick}
+          className="w-[80px] cursor-pointer rounded-2xl bg-gray-500 p-2 text-center text-[18px] text-white"
+        >
+          Skip
+        </button>
+      ) : null}
+    </>
+  );
+};
+
+export default SkipButton;

--- a/src/components/CanvasToolBar/SyncButton.tsx
+++ b/src/components/CanvasToolBar/SyncButton.tsx
@@ -1,0 +1,9 @@
+const SyncButton = () => {
+  return (
+    <button className="w-[80px] cursor-pointer rounded-2xl bg-primary  p-2 text-center text-[18px] text-white">
+      Sync
+    </button>
+  );
+};
+
+export default SyncButton;

--- a/src/components/CanvasToolBar/VoteButton.tsx
+++ b/src/components/CanvasToolBar/VoteButton.tsx
@@ -1,0 +1,30 @@
+import useModalStore from "@/store/useModalStore";
+import { useMyPresence } from "~/liveblocks.config";
+
+const VOTE_PROCESSES = [3];
+
+const VoteButton = () => {
+  const { setModalType, setModalState } = useModalStore();
+  const [myPresence] = useMyPresence();
+  const { currentProcess } = myPresence;
+
+  const handleVoteButtonClick = () => {
+    setModalType("vote");
+    setModalState(true);
+  };
+
+  return (
+    <>
+      {VOTE_PROCESSES.includes(currentProcess) ? (
+        <button
+          onClick={handleVoteButtonClick}
+          className="w-[80px] cursor-pointer rounded-2xl bg-primary-500 p-2 text-center text-[18px] text-white"
+        >
+          Vote
+        </button>
+      ) : null}
+    </>
+  );
+};
+
+export default VoteButton;

--- a/src/components/CanvasToolBar/index.tsx
+++ b/src/components/CanvasToolBar/index.tsx
@@ -9,6 +9,7 @@ import { CanvasMode, LayerType, CanvasState } from "@/lib/types";
 import TextButton from "./TextButton";
 import NoteButton from "./NoteButton";
 import StickerButton from "./StickerButton";
+import CanvasButton from "./CanvasButton";
 
 type Props = {
   canvasState: CanvasState;
@@ -113,6 +114,9 @@ export default function ToolsBar({
           <UndoButton onClick={undo} disabled={!canUndo} />
           <RedoButton onClick={redo} disabled={!canRedo} />
         </div>
+      </div>
+      <div className="absolute bottom-[6rem] flex h-[5rem] w-[30rem] items-center justify-center">
+        <CanvasButton />
       </div>
     </div>
   );

--- a/src/components/Layout/ProcessNav/index.tsx
+++ b/src/components/Layout/ProcessNav/index.tsx
@@ -79,7 +79,7 @@ const ProcessNav = ({
           height={18}
           className="cursor-pointer"
           onClick={() => {
-            setModalState(true), setModalType("skip");
+            setModalState(true), setModalType("guide");
           }}
         />
       </div>

--- a/src/components/Modals/CompleteModal.tsx
+++ b/src/components/Modals/CompleteModal.tsx
@@ -4,12 +4,15 @@ const CompleteModal = () => {
   const { setModalState } = useModalStore();
 
   return (
-    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[50rem] py-[40rem] text-center">
-      <div className=" space-around flex h-full w-[60rem] flex-col bg-white">
-        <div className="h-full">투표가 완료되었습니다.</div>
-        <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[4rem] border p-[8px]">
+    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen min-w-[100rem] items-center justify-center bg-black bg-opacity-70 px-[28rem] py-[4rem] text-center">
+      <div className=" flex h-[20rem] w-[40rem] flex-col bg-white">
+        <div className="border-grey-100 flex h-full items-center justify-center border p-[8px]">
+          투표가 완료되었습니다.
+        </div>
+
+        <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[3rem] border p-[8px]">
           <button
-            className="w-[80px] cursor-pointer rounded-2xl bg-gray-700  p-2 text-center text-[18px] text-white"
+            className="w-[80px] cursor-pointer rounded-2xl bg-primary  p-2 text-center text-[18px] text-white"
             onClick={() => setModalState(false)}
           >
             닫기

--- a/src/components/Modals/CompleteModal.tsx
+++ b/src/components/Modals/CompleteModal.tsx
@@ -1,0 +1,23 @@
+import useModalStore from "@/store/useModalStore";
+
+const CompleteModal = () => {
+  const { setModalState } = useModalStore();
+
+  return (
+    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[50rem] py-[40rem] text-center">
+      <div className=" space-around flex h-full w-[60rem] flex-col bg-white">
+        <div className="h-full">투표가 완료되었습니다.</div>
+        <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[4rem] border p-[8px]">
+          <button
+            className="w-[80px] cursor-pointer rounded-2xl bg-gray-700  p-2 text-center text-[18px] text-white"
+            onClick={() => setModalState(false)}
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompleteModal;

--- a/src/components/Modals/SkipModal.tsx
+++ b/src/components/Modals/SkipModal.tsx
@@ -22,12 +22,12 @@ const SkipModal = () => {
 
   return (
     <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[50rem] py-[40rem] text-center">
-      <div className=" space-around flex h-full w-full flex-col bg-white">
+      <div className=" space-around flex h-full w-[60rem] flex-col bg-white">
         <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
           스킵
         </div>
         <div className="h-full">{currentProcess}단계를 건너뛸까요?</div>
-        <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
+        <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[4rem] border p-[8px]">
           <button
             className="w-[80px] cursor-pointer rounded-2xl bg-gray-700  p-2 text-center text-[18px] text-white"
             onClick={() => setModalState(false)}

--- a/src/components/Modals/VoteModal.tsx
+++ b/src/components/Modals/VoteModal.tsx
@@ -1,16 +1,52 @@
+import { useMyPresence, useUpdateMyPresence } from "~/liveblocks.config";
 import useModalStore from "@/store/useModalStore";
+import { useState } from "react";
 
 const VoteModal = () => {
-  const { isOpen, setModalState } = useModalStore();
+  const [myPresence] = useMyPresence();
+  const { currentProcess } = myPresence;
+  const { isOpen, setModalState, setModalType } = useModalStore();
+  const [vote, setVote] = useState<number | null>(null);
+  const [voteCompleted, setVoteCompleted] = useState<boolean>(false);
+  const handleVote = (key: number) => () => {
+    setVote(key);
+    setVoteCompleted(true);
+  };
 
+  const submitVote = () => {
+    setModalType("complete");
+    //유저의 투표 상태 및 투표 정보 업데이트 추가 필요
+  };
   return (
-    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[24rem] py-[4rem] text-center">
+    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[28rem] py-[4rem] text-center">
       <div className=" flex h-full w-full flex-col bg-white">
         <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
           투표
         </div>
-        <div className="h-full"></div>
-        <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
+        <div className="flex h-full w-full items-center justify-center">
+          <div className="grid grid-cols-3 grid-rows-2 gap-48">
+            {Array.from({ length: 6 }, (_, index) => (
+              <div
+                key={index}
+                className={`flex h-[30rem] w-[30rem] items-center justify-center rounded-full border border-[1rem] font-mono text-9xl font-semibold text-gray-200 ${
+                  vote === index + 1 ? "bg-primary" : ""
+                }`}
+                onClick={handleVote(index + 1)}
+              >
+                <text fontFamily="Arial" fontSize="200" fill="#F0F2F5">
+                  {index + 1}
+                </text>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[3rem] border p-[8px]">
+          <button
+            onClick={submitVote}
+            className="w-[80px] cursor-pointer rounded-2xl bg-primary-500 p-2 text-center text-[18px] text-white"
+          >
+            완료
+          </button>
           <button
             className="w-[80px] cursor-pointer rounded-2xl bg-primary  p-2 text-center text-[18px] text-white"
             onClick={() => setModalState(false)}

--- a/src/components/Modals/VoteModal.tsx
+++ b/src/components/Modals/VoteModal.tsx
@@ -14,21 +14,23 @@ const VoteModal = () => {
   };
 
   const submitVote = () => {
-    setModalType("complete");
+    if (vote) {
+      setModalType("complete");
+    }
     //유저의 투표 상태 및 투표 정보 업데이트 추가 필요
   };
   return (
-    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[28rem] py-[4rem] text-center">
+    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen min-w-[100rem] items-center justify-center bg-black bg-opacity-70 px-[28rem] py-[4rem] text-center">
       <div className=" flex h-full w-full flex-col bg-white">
         <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
           투표
         </div>
         <div className="flex h-full w-full items-center justify-center">
-          <div className="grid grid-cols-3 grid-rows-2 gap-48">
+          <div className="grid grid-cols-3 grid-rows-2 gap-[8rem]">
             {Array.from({ length: 6 }, (_, index) => (
               <div
                 key={index}
-                className={`flex h-[30rem] w-[30rem] items-center justify-center rounded-full border border-[1rem] font-mono text-9xl font-semibold text-gray-200 ${
+                className={`flex h-[20rem] w-[20rem] items-center justify-center rounded-full border border-[1rem] font-mono text-9xl font-semibold text-gray-200 ${
                   vote === index + 1 ? "bg-primary" : ""
                 }`}
                 onClick={handleVote(index + 1)}

--- a/src/components/Modals/VoteModal.tsx
+++ b/src/components/Modals/VoteModal.tsx
@@ -1,0 +1,26 @@
+import useModalStore from "@/store/useModalStore";
+
+const VoteModal = () => {
+  const { isOpen, setModalState } = useModalStore();
+
+  return (
+    <div className="fixed left-0 top-0 z-30 flex h-screen w-screen items-center justify-center bg-black bg-opacity-70 px-[24rem] py-[4rem] text-center">
+      <div className=" flex h-full w-full flex-col bg-white">
+        <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
+          투표
+        </div>
+        <div className="h-full"></div>
+        <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
+          <button
+            className="w-[80px] cursor-pointer rounded-2xl bg-primary  p-2 text-center text-[18px] text-white"
+            onClick={() => setModalState(false)}
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VoteModal;

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -2,7 +2,7 @@ import useModalStore from "@/store/useModalStore";
 import GuideModal from "./GuideModal";
 import SkipModal from "./SkipModal";
 import VoteModal from "./VoteModal";
-
+import CompleteModal from "./CompleteModal";
 interface ModalMapType {
   [key: string]: () => JSX.Element;
 }
@@ -11,6 +11,7 @@ const ModalMap: ModalMapType = {
   guide: GuideModal,
   skip: SkipModal,
   vote: VoteModal,
+  complete: CompleteModal,
 };
 
 const Modal = () => {

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -1,7 +1,7 @@
 import useModalStore from "@/store/useModalStore";
 import GuideModal from "./GuideModal";
 import SkipModal from "./SkipModal";
-import { useState, useEffect } from "react";
+import VoteModal from "./VoteModal";
 
 interface ModalMapType {
   [key: string]: () => JSX.Element;
@@ -10,6 +10,7 @@ interface ModalMapType {
 const ModalMap: ModalMapType = {
   guide: GuideModal,
   skip: SkipModal,
+  vote: VoteModal,
 };
 
 const Modal = () => {


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close #60 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 💻 작업 내용

> CanvasButton.tsx 라는 컴포넌트를 만들고, 내부에서 Skip, Vote, Sync 버튼을 출력합니다.

- Sync 버튼은 항상 렌더링 됩니다
- Skip 버튼은 currentProcess가 1,2,10,11에서만,
- Vote 버튼은 3단계 에서만 렌더링 됩니다.
- Vote 버튼 클릭 시 투표 모달이 뜹니다
- 투표 모달 창에서는 버튼을 누르고 vote 버튼을 누를 수 있습니다.
- 투표가 완료되면 완료 모달이 뜹니다.

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요
![image](https://github.com/i-Dear/sync-d-frontend/assets/91151775/77a5c4c1-6e55-4c2c-8d4b-03b11c68a738)
![image](https://github.com/i-Dear/sync-d-frontend/assets/91151775/6911c88a-46ca-4a51-b2bc-61917b854949)
![image](https://github.com/i-Dear/sync-d-frontend/assets/91151775/a25adf43-028c-49fa-bfc6-affa06529df2)

