### PR TITLE
[#76] Feat: 2단계 템플릿 구현 및 storage활용 공유 인풋 폼 완성

### DIFF
--- a/src/components/Canvas/TemplateComponent.tsx
+++ b/src/components/Canvas/TemplateComponent.tsx
@@ -2,13 +2,11 @@ import React, { memo } from "react";
 import { Template, TemplateType } from "@/lib/types";
 import NoteBox from "../ProcessContent/NoteBox";
 import GuideTextBox from "../ProcessContent/GuideTextBox";
-
+import InputFormBox from "../ProcessContent/InputFormBox";
 const TemplateComponent = memo(({ template }: { template: Template }) => {
   if (!template) {
     return null;
   }
-
-  console.log("TemplateComponent", template);
 
   switch (template.type) {
     case TemplateType.NoteBox:
@@ -35,6 +33,23 @@ const TemplateComponent = memo(({ template }: { template: Template }) => {
           height={template.height}
           title={template.title}
           fill={template.fill}
+          font={template.font}
+          fontWeight={template.fontWeight}
+        />
+      );
+    case TemplateType.InputFormBox:
+      return (
+        <InputFormBox
+          id={template.id}
+          type={template.type}
+          x={template.x}
+          y={template.y}
+          width={template.width}
+          height={template.height}
+          title={template.title}
+          font={template.font}
+          fontWeight={template.fontWeight}
+          value={template.value}
         />
       );
 

--- a/src/components/ProcessContent/GuideTextBox.tsx
+++ b/src/components/ProcessContent/GuideTextBox.tsx
@@ -1,16 +1,15 @@
 import { GuideTextBoxTemplate } from "@/lib/types";
 
 export default function GuideTextBox(props: GuideTextBoxTemplate) {
-  const { title, x, y, width, height, fill } = props;
-
+  const { title, x, y, width, height, fill, font, fontWeight } = props;
   return (
     <g>
       <rect
-        width={width}
+        width={width ? width : 800}
         x={x}
         y={y}
-        height={height}
-        fill={fill}
+        height={height ? height : 50}
+        fill={fill ? fill : "none"}
         stroke={"transparent"}
       />
       {props.title && (
@@ -18,9 +17,9 @@ export default function GuideTextBox(props: GuideTextBoxTemplate) {
           x={x + 20}
           y={y + 40}
           fontFamily="Arial"
-          fontSize="14"
+          fontSize={font ? font : "14"}
           fill="#121417"
-          fontWeight={"bold"}
+          fontWeight={fontWeight ? fontWeight : "bold"}
         >
           {title?.split("\n").map((line, index) => (
             <tspan x={x + 20} dy={index > 0 ? "1.2em" : 0} key={index}>

--- a/src/components/ProcessContent/InputFormBox.tsx
+++ b/src/components/ProcessContent/InputFormBox.tsx
@@ -1,0 +1,69 @@
+import { InputFormBoxTemplate } from "@/lib/types";
+import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
+import { useMutation } from "~/liveblocks.config";
+import React, { useState } from "react";
+import { TemplateType } from "@/lib/types";
+
+export default function InputFormBox(props: InputFormBoxTemplate) {
+  const { id, title, x, y, width, height, fontWeight, font, value } = props;
+
+  const updateValue = useMutation(({ storage }, newValue: string) => {
+    const liveTemplates = storage.get("templates");
+    liveTemplates.map((v) => console.log(v));
+    const targetFormIdx = liveTemplates.findIndex(
+      (template) => template.id === id,
+    );
+    liveTemplates.set(targetFormIdx, {
+      id: id,
+      type: TemplateType.InputFormBox,
+      title: title,
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+      font: font,
+      fontWeight: fontWeight,
+      value: newValue,
+    });
+  }, []);
+
+  const [isPlaceholderVisible, setPlaceholderVisible] = useState(!value);
+
+  const handleContentChange = (e: ContentEditableEvent) => {
+    const newValue = e.target.value;
+    updateValue(newValue);
+  };
+
+  const handleFocus = () => {
+    if (isPlaceholderVisible) {
+      setPlaceholderVisible(false);
+    }
+  };
+
+  return (
+    <foreignObject
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      style={{ border: "4px solid black" }}
+      className="shadow-grey-950 shadow-lg drop-shadow-lg"
+    >
+      <ContentEditable
+        html={
+          isPlaceholderVisible
+            ? "<span class='placeholder' style='color: #999'>type your own text</span>"
+            : value || ""
+        }
+        onChange={handleContentChange}
+        onFocus={handleFocus}
+        className="flex h-full w-full justify-normal p-[1rem] outline-none "
+        style={{
+          fontSize: 12,
+          color: "black",
+          fontFamily: "Manrope, sans-serif",
+        }}
+      />
+    </foreignObject>
+  );
+}

--- a/src/components/ProcessContent/InputFormBox.tsx
+++ b/src/components/ProcessContent/InputFormBox.tsx
@@ -2,10 +2,9 @@ import { InputFormBoxTemplate } from "@/lib/types";
 import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
 import { useMutation } from "~/liveblocks.config";
 import React, { useState } from "react";
-import { TemplateType } from "@/lib/types";
 
 export default function InputFormBox(props: InputFormBoxTemplate) {
-  const { id, title, x, y, width, height, fontWeight, font, value } = props;
+  const { id, x, y, width, height, font, value } = props;
 
   const updateValue = useMutation(({ storage }, newValue: string) => {
     const liveTemplates = storage.get("templates");
@@ -13,15 +12,7 @@ export default function InputFormBox(props: InputFormBoxTemplate) {
       (template) => template.id === id,
     );
     liveTemplates.set(targetFormIdx, {
-      id: id,
-      type: TemplateType.InputFormBox,
-      title: title,
-      x: x,
-      y: y,
-      width: width,
-      height: height,
-      font: font,
-      fontWeight: fontWeight,
+      ...props,
       value: newValue,
     });
   }, []);
@@ -43,22 +34,21 @@ export default function InputFormBox(props: InputFormBoxTemplate) {
     <foreignObject
       x={x}
       y={y}
-      width={width}
-      height={height}
-      style={{ border: "4px solid black" }}
-      className="shadow-grey-950 shadow-lg drop-shadow-lg"
+      width={width ? width : 800}
+      height={height ? height : 200}
+      style={{ borderBottom: "4px solid black" }}
     >
       <ContentEditable
         html={
           isPlaceholderVisible
-            ? "<span class='placeholder' style='color: #999'>type your own text</span>"
+            ? "<span class='placeholder' style='color: #999'>우리 팀의 목표는</span>"
             : value || ""
         }
         onChange={handleContentChange}
         onFocus={handleFocus}
         className="flex h-full w-full justify-normal p-[1rem] outline-none "
         style={{
-          fontSize: 12,
+          fontSize: font ? font : 12,
           color: "black",
           fontFamily: "Manrope, sans-serif",
         }}

--- a/src/components/ProcessContent/InputFormBox.tsx
+++ b/src/components/ProcessContent/InputFormBox.tsx
@@ -46,12 +46,7 @@ export default function InputFormBox(props: InputFormBoxTemplate) {
         }
         onChange={handleContentChange}
         onFocus={handleFocus}
-        className="flex h-full w-full justify-normal p-[1rem] outline-none "
-        style={{
-          fontSize: font ? font : 12,
-          color: "black",
-          fontFamily: "Manrope, sans-serif",
-        }}
+        className={`flex h-full w-full justify-normal p-[1rem] outline-none ${font ? font : "text-base"} font-Manrope text-black`}
       />
     </foreignObject>
   );

--- a/src/components/ProcessContent/InputFormBox.tsx
+++ b/src/components/ProcessContent/InputFormBox.tsx
@@ -9,7 +9,6 @@ export default function InputFormBox(props: InputFormBoxTemplate) {
 
   const updateValue = useMutation(({ storage }, newValue: string) => {
     const liveTemplates = storage.get("templates");
-    liveTemplates.map((v) => console.log(v));
     const targetFormIdx = liveTemplates.findIndex(
       (template) => template.id === id,
     );

--- a/src/components/ProcessContent/NoteBox.tsx
+++ b/src/components/ProcessContent/NoteBox.tsx
@@ -6,10 +6,10 @@ export default function NoteBox(props: NoteBoxTemplate) {
   return (
     <g>
       <rect
-        width={width}
+        width={width ? width : 800}
         x={x}
         y={y}
-        height={height}
+        height={height ? height : 200}
         fill={fill}
         stroke={"transparent"}
       />

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -7,8 +7,6 @@ export const syncTemplates: Template[] = [
     title: "60초 자기소개 Time !",
     x: 200,
     y: 50,
-    width: 800,
-    height: 200,
     fill: "#FFF0C8",
   },
   {
@@ -17,8 +15,7 @@ export const syncTemplates: Template[] = [
     title: "제 강점과 약점은요,",
     x: 200,
     y: 300,
-    width: 800,
-    height: 200,
+
     fill: "#C8FFD1",
   },
   {
@@ -27,8 +24,7 @@ export const syncTemplates: Template[] = [
     title: "이것만은 부탁해요!",
     x: 200,
     y: 550,
-    width: 800,
-    height: 200,
+
     fill: "#C8F5FF",
   },
   {
@@ -38,9 +34,6 @@ export const syncTemplates: Template[] = [
       "무슨 말이라도 좋아요 ! 팀원들이 서로를 잘 알고 편안한 감정을 가질 수록 팀 전체의 문제 해결 능력이 향상된다는 연구 결과가 있어요😃",
     x: 240,
     y: 0,
-    width: 800,
-    height: 50,
-    fill: "#FFFFFF",
   },
   {
     id: "11",
@@ -49,9 +42,6 @@ export const syncTemplates: Template[] = [
       "사람은 모든 면에서 완벽할 수 없어요. 부끄러워하지 않아도 괜찮아요 ! 서로의 강점과 약점을 공유하는 시간을 가져봐요😉",
     x: 200,
     y: 250,
-    width: 800,
-    height: 50,
-    fill: "#FFFFFF",
   },
   {
     id: "12",
@@ -60,20 +50,95 @@ export const syncTemplates: Template[] = [
       "프로젝트를 시작하기 앞서, 팀원들에게 이것만은 솔직하게 부탁하고 싶어요!",
     x: 200,
     y: 500,
-    width: 800,
-    height: 50,
-    fill: "#FFFFFF",
   },
   {
     id: "200",
     type: TemplateType.GuideTextBox,
-    title:
-      "프로젝트를 통해 얻어가고 싶은 목표를 적어주세요 ! \n우리는 각자 프로젝트에서 얻어가고자 하는 목표가 다를 수 있고, 이 점을 서로 존중하고 이해해줘야 해요☺️",
+    title: "프로젝트 내 개인목표",
     x: 225,
     y: 1000,
     width: 800,
+    height: 25,
+    font: 18,
+    fontWeight: "bold",
+    fill: "none",
+  },
+  {
+    id: "201",
+    type: TemplateType.GuideTextBox,
+    title:
+      "프로젝트를 통해 얻어가고 싶은 목표를 적어주세요 ! \n우리는 각자 프로젝트에서 얻어가고자 하는 목표가 다를 수 있고, 이 점을 서로 존중하고 이해해줘야 해요☺️",
+    x: 200,
+    y: 1025,
+    width: 800,
     height: 50,
-    fill: "#FFFFFF",
+    fontWeight: "light",
+    fill: "none",
+  },
+  {
+    id: "202",
+    type: TemplateType.NoteBox,
+    title: "이것만은 부탁해요!",
+    x: 200,
+    y: 1100,
+    width: 800,
+    height: 200,
+    fill: "#C8F5FF",
+  },
+  {
+    id: "203",
+    type: TemplateType.GuideTextBox,
+    title: "프로젝트 내 팀목표",
+    x: 225,
+    y: 1300,
+    width: 800,
+    height: 25,
+    font: 18,
+    fontWeight: "bold",
+  },
+  {
+    id: "204",
+    type: TemplateType.GuideTextBox,
+    title:
+      "각자 다른 목표를 가지고 있어도, 우리는 결국 합의된 하나의 목표를 바라봐야해요.\n모두의 개인 목표를 토대로 우리 팀의 목표는 이걸로 하면 어떨까? 하는 의견을 자유롭게 적어주세요 !",
+    x: 200,
+    y: 1325,
+    width: 800,
+    height: 50,
+    fontWeight: "light",
+  },
+  {
+    id: "205",
+    type: TemplateType.NoteBox,
+    title: "이것만은 부탁해요!",
+    x: 200,
+    y: 1400,
+    width: 800,
+    height: 200,
+    fill: "#C8F5FF",
+  },
+  {
+    id: "206",
+    type: TemplateType.GuideTextBox,
+    title: "한 문장으로 팀의 목표를 정의해주세요!",
+    x: 200,
+    y: 1600,
+    width: 800,
+    height: 50,
+    font: 20,
+    fontWeight: "bold",
+  },
+  {
+    id: "207",
+    type: TemplateType.InputFormBox,
+    title: "한 문장으로 팀의 목표를 정의해주세요!",
+    x: 200,
+    y: 1650,
+    width: 800,
+    height: 50,
+    font: 20,
+    fontWeight: "bold",
+    value: "",
   },
   {
     id: "400",
@@ -84,7 +149,6 @@ export const syncTemplates: Template[] = [
     y: 3020,
     width: 800,
     height: 200,
-    fill: "#FFFFFF",
   },
   {
     id: "500",
@@ -95,7 +159,6 @@ export const syncTemplates: Template[] = [
     y: 4020,
     width: 800,
     height: 200,
-    fill: "#FFFFFF",
   },
 
   {
@@ -107,7 +170,6 @@ export const syncTemplates: Template[] = [
     y: 5020,
     width: 800,
     height: 200,
-    fill: "#FFFFFF",
   },
   {
     id: "700",
@@ -117,7 +179,6 @@ export const syncTemplates: Template[] = [
     y: 6020,
     width: 800,
     height: 50,
-    fill: "#FFFFFF",
   },
   {
     id: "800",
@@ -128,7 +189,6 @@ export const syncTemplates: Template[] = [
     y: 7020,
     width: 800,
     height: 300,
-    fill: "#FFFFFF",
   },
   {
     id: "900",
@@ -139,7 +199,6 @@ export const syncTemplates: Template[] = [
     y: 8020,
     width: 800,
     height: 300,
-    fill: "#FFFFFF",
   },
   {
     id: "1000",
@@ -150,7 +209,6 @@ export const syncTemplates: Template[] = [
     y: 9020,
     width: 800,
     height: 300,
-    fill: "#FFFFFF",
   },
   {
     id: "1100",
@@ -161,7 +219,6 @@ export const syncTemplates: Template[] = [
     y: 10020,
     width: 800,
     height: 300,
-    fill: "#FFFFFF",
   },
   {
     id: "1200",
@@ -172,6 +229,5 @@ export const syncTemplates: Template[] = [
     y: 11020,
     width: 800,
     height: 300,
-    fill: "#FFFFFF",
   },
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -191,9 +191,13 @@ export enum CanvasMode {
 export enum TemplateType {
   NoteBox,
   GuideTextBox,
+  InputFormBox,
 }
 
-export type Template = NoteBoxTemplate | GuideTextBoxTemplate;
+export type Template =
+  | NoteBoxTemplate
+  | GuideTextBoxTemplate
+  | InputFormBoxTemplate;
 
 export type NoteBoxTemplate = {
   type: TemplateType.NoteBox;
@@ -201,9 +205,9 @@ export type NoteBoxTemplate = {
   title?: string;
   x: number;
   y: number;
-  width: number;
-  height: number;
-  fill: string;
+  width?: number;
+  height?: number;
+  fill?: string;
 };
 
 export type GuideTextBoxTemplate = {
@@ -212,7 +216,22 @@ export type GuideTextBoxTemplate = {
   title?: string;
   x: number;
   y: number;
-  width: number;
-  height: number;
-  fill: string;
+  width?: number;
+  height?: number;
+  fill?: string;
+  font?: number;
+  fontWeight?: string;
+};
+
+export type InputFormBoxTemplate = {
+  type: TemplateType.InputFormBox;
+  id: string;
+  title?: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  font?: number;
+  fontWeight?: string;
+  value?: string;
 };


### PR DESCRIPTION
## #️⃣ 연관 이슈

close #76

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 💻 작업 내용

- template.ts에서 너무 많은 불필요한 혹은 중복이 있는 요소들이 (width, height, fill, font, 등) 존재하여 default 값을 설정하고 폰트 크기나 굵기 설정이 필요하지 않은 Template NoteBox나 GuideText에서는 template.ts에서 해당 요소를 입력하지 않아도 되도록 수정하였습니다.
- 2단계 템플릿을 추가하였습니다.
- storage를 활용하는 공유 inputForm을 구현하였습니다.
template.ts에 추가되는 템플릿들은 livelist[]의 형태입니다. livelist에서 사용 가능한 메소드를 타고 들어가보면 findIndex와 set 함수가 있는데, 이 함수들을 활용하여 template이름을 가진 livelist내에서 form의 id값이 일치하는 요소를 찾아 value를 수정해주는 방식으로 공유 인풋폼을 만들었습니다.

### 테스트 결과 or 스크린샷 (선택)
<img width="1026" alt="image" src="https://github.com/i-Dear/sync-d-frontend/assets/91151775/81cf2e56-1fea-4c7b-bb1c-b2959cc60db7">

