### PR TITLE
[#87] Feat: 보더 색상 선택 후 드래그 앤 드롭으로 노드 추가 로직 구현

### DIFF
--- a/src/components/Canvas/index.tsx
+++ b/src/components/Canvas/index.tsx
@@ -54,16 +54,15 @@ import ProcessNav from "../Layout/ProcessNav";
 import useDeleteLayersBackspace from "@/hooks/useDeleteLayersBackspace";
 import TemplateComponent from "./TemplateComponent";
 import { syncTemplates } from "@/lib/templates";
-import ReactFlow, {
+import {
   Connection,
-  Controls,
   EdgeChange,
-  MiniMap,
   NodeChange,
   addEdge,
   applyEdgeChanges,
   applyNodeChanges,
 } from "reactflow";
+import DnDFlow from "../FlowCanvas/DnDFlow";
 
 const MAX_LAYERS = 100;
 
@@ -530,9 +529,9 @@ const Canvas = () => {
     <div>
       <CollabToolAside roomId={groupCall.roomId} />
       <ProcessNav userInfo={userInfo} setCamera={setCamera} />
-      {[9, 10, 11, 12].includes(currentProcess) && (
+      {[9, 12].includes(currentProcess) && (
         <div className="relative h-screen w-screen bg-white">
-          <ReactFlow
+          {/* <ReactFlow
             nodes={nodes}
             edges={edges}
             onNodesChange={onNodesChange}
@@ -542,7 +541,8 @@ const Canvas = () => {
           >
             <MiniMap />
             <Controls />
-          </ReactFlow>
+          </ReactFlow> */}
+          <DnDFlow />
         </div>
       )}
       <div

--- a/src/components/FlowCanvas/DnDFlow/ColorSelector.tsx
+++ b/src/components/FlowCanvas/DnDFlow/ColorSelector.tsx
@@ -1,0 +1,26 @@
+const ColorSelector = ({
+  nodeBorderColor,
+  setNodeBorderColor,
+}: {
+  nodeBorderColor: string;
+  setNodeBorderColor: (color: string) => void;
+}) => {
+  return (
+    <div
+      className="absolute right-[30rem] top-[10rem] rounded-[0.4rem] border border-div-text bg-light-gray-100 px-[1.5rem] py-[1rem] text-[1.2rem] md:w-[20%] md:max-w-[25rem]
+    "
+    >
+      <div>
+        Pick a color 🎨 <strong>{nodeBorderColor}</strong>
+      </div>
+      <input
+        className="nodrag"
+        type="color"
+        onChange={(e) => setNodeBorderColor(e.target.value)}
+        defaultValue={nodeBorderColor}
+      />
+    </div>
+  );
+};
+
+export default ColorSelector;

--- a/src/components/FlowCanvas/DnDFlow/Sidebar.tsx
+++ b/src/components/FlowCanvas/DnDFlow/Sidebar.tsx
@@ -1,0 +1,24 @@
+const SideBar = () => {
+  const onDragStart = (
+    event: React.DragEvent<HTMLDivElement>,
+    nodeType: any,
+  ) => {
+    event.dataTransfer.setData("application/reactflow", nodeType);
+    event.dataTransfer.effectAllowed = "move";
+  };
+
+  return (
+    <aside className="absolute bottom-[10rem] left-[10rem]  bg-light-gray-100 px-[1.5rem] py-[1rem] text-[1.2rem] md:w-[20%] md:max-w-[25rem]">
+      <div className="bg-[1rem]">색상을 선택하고, 캔버스에 올려놓으세요 !</div>
+      <div
+        className="mb-[1rem] flex h-[2rem] cursor-grab items-center justify-center rounded-[0.4rem] border border-div-text p-[0.4rem]"
+        onDragStart={(event) => onDragStart(event, "default")}
+        draggable
+      >
+        Default Node
+      </div>
+    </aside>
+  );
+};
+
+export default SideBar;

--- a/src/components/FlowCanvas/DnDFlow/index.tsx
+++ b/src/components/FlowCanvas/DnDFlow/index.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useRef, useCallback } from "react";
+import ReactFlow, {
+  ReactFlowProvider,
+  addEdge,
+  Controls,
+  Connection,
+  ReactFlowInstance,
+  NodeChange,
+  Node,
+  applyNodeChanges,
+  applyEdgeChanges,
+  EdgeChange,
+} from "reactflow";
+import "reactflow/dist/style.css";
+import StakeholderNode from "./StakeholderNode";
+
+import Sidebar from "./Sidebar";
+
+import { useMutation, useStorage } from "~/liveblocks.config";
+import ColorSelector from "./ColorSelector";
+
+let id = 0;
+const getId = () => `node_${id++}`;
+
+const defaultViewport = { x: 0, y: 0, zoom: 1.5 };
+
+const nodeTypes = {
+  stakeholder: StakeholderNode,
+};
+
+const DnDFlow = () => {
+  const nodes = useStorage((root) => root.nodes);
+  const edges = useStorage((root) => root.edges);
+  const [nodeBorderColor, setNodeBorderColor] = useState("#121417");
+  const reactFlowWrapper = useRef(null);
+  const [reactFlowInstance, setReactFlowInstance] =
+    useState<ReactFlowInstance>();
+
+  const onConnect = useMutation(
+    ({ storage }, connection: Connection) => {
+      const existingEdges = storage.get("edges");
+      storage.set("edges", addEdge(connection, existingEdges));
+    },
+    [edges],
+  );
+
+  const addNode = useMutation(
+    ({ storage }, node: Node) => {
+      const existingNodes = storage.get("nodes");
+      storage.set("nodes", [...existingNodes, node]);
+    },
+    [nodes],
+  );
+
+  const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+
+      const type = event.dataTransfer.getData("application/reactflow");
+
+      if (typeof type === "undefined" || !type) {
+        return;
+      }
+
+      if (!reactFlowInstance) {
+        return;
+      }
+
+      const position = reactFlowInstance.screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      const newNode = {
+        id: getId(),
+        type,
+        position,
+        data: { label: `${type} node` },
+        style: {
+          border: `2px solid ${nodeBorderColor}`,
+          background: "#fff",
+          color: "#121417",
+          width: 200,
+        },
+      };
+
+      addNode(newNode);
+    },
+    [reactFlowInstance, nodeBorderColor, addNode],
+  );
+
+  const onNodesChange = useMutation(
+    ({ storage }, changes: NodeChange[]) => {
+      storage.set("nodes", applyNodeChanges(changes, nodes));
+    },
+    [nodes],
+  );
+
+  const onEdgesChange = useMutation(
+    ({ storage }, changes: EdgeChange[]) => {
+      storage.set("edges", applyEdgeChanges(changes, edges));
+    },
+    [edges],
+  );
+
+  return (
+    <div className="flex h-full w-full grow flex-col">
+      <ReactFlowProvider>
+        <div className="h-full w-full grow" ref={reactFlowWrapper}>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            defaultViewport={defaultViewport}
+            onInit={setReactFlowInstance}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+          >
+            <Controls />
+          </ReactFlow>
+          <ColorSelector
+            nodeBorderColor={nodeBorderColor}
+            setNodeBorderColor={setNodeBorderColor}
+          />
+        </div>
+        <Sidebar />
+      </ReactFlowProvider>
+    </div>
+  );
+};
+
+export default DnDFlow;

--- a/src/components/FlowCanvas/DnDFlow/index.tsx
+++ b/src/components/FlowCanvas/DnDFlow/index.tsx
@@ -12,7 +12,7 @@ import ReactFlow, {
   EdgeChange,
 } from "reactflow";
 import "reactflow/dist/style.css";
-import StakeholderNode from "./StakeholderNode";
+// import StakeholderNode from "./StakeholderNode";
 
 import Sidebar from "./Sidebar";
 
@@ -24,9 +24,9 @@ const getId = () => `node_${id++}`;
 
 const defaultViewport = { x: 0, y: 0, zoom: 1.5 };
 
-const nodeTypes = {
-  stakeholder: StakeholderNode,
-};
+// const nodeTypes = {
+//     stakeholder: StakeholderNode,
+//   };
 
 const DnDFlow = () => {
   const nodes = useStorage((root) => root.nodes);


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close #87 
> #81 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] Sidebar에서 드래그 후 reactflow 캔버스에 드랍하여 노드 추가
- [x] ColorSelector에서 색상 선택 후 드래그 앤 드랍 시 해당 스타일 적용한 노드 추가

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

https://github.com/i-Dear/sync-d-frontend/assets/121740394/f94b40e7-51c8-4aca-835a-bb628431df09

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

현재 Default node가 최대 개수 5개로 제한되어 있습니다.
