### PR TITLE
[#102] Feat: Sync 버튼 클릭 시 set camera 액션 발생

### DIFF
--- a/src/components/Canvas/index.tsx
+++ b/src/components/Canvas/index.tsx
@@ -63,6 +63,7 @@ import {
   applyNodeChanges,
 } from "reactflow";
 import DnDFlow from "../FlowCanvas/DnDFlow";
+import Modal from "@/components/Modals";
 
 const MAX_LAYERS = 100;
 
@@ -622,6 +623,7 @@ const Canvas = () => {
         canUndo={canUndo}
         canRedo={canRedo}
       />
+      <Modal setCamera={setCamera} />
     </div>
   );
 };

--- a/src/components/CanvasToolBar/SkipButton.tsx
+++ b/src/components/CanvasToolBar/SkipButton.tsx
@@ -1,12 +1,24 @@
 import useModalStore from "@/store/useModalStore";
-import { useMyPresence } from "~/liveblocks.config";
+import { useState, useEffect } from "react";
+import { useMyPresence, useStorage } from "~/liveblocks.config";
 
 const SKIPABLE_PROCESSES = [1, 2, 10, 11];
 
 const SkipButton = () => {
   const { setModalType, setModalState } = useModalStore();
+
   const [myPresence] = useMyPresence();
-  const { currentProcess } = myPresence;
+  const [currentProcess, setCurrentProcess] = useState(
+    myPresence.currentProcess,
+  );
+
+  const processes = useStorage((storage) => storage.process);
+
+  useEffect(() => {
+    const latestUndoneProcess = processes.find((process) => !process.done);
+    const latestUndoneStep = latestUndoneProcess?.step;
+    setCurrentProcess(latestUndoneStep || 1);
+  }, [processes]);
 
   const handleSkipButtonClick = () => {
     setModalType("skip");

--- a/src/components/Layout/ProcessNav/index.tsx
+++ b/src/components/Layout/ProcessNav/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { UserInfoStoreType } from "@/store/useUserInfoStore";
-import { SetStateAction, useState } from "react";
+import { SetStateAction, useState, useEffect } from "react";
 import { Camera } from "@/lib/types";
 import {
   useMutation,
@@ -14,6 +14,7 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import CompleteIcon from "~/public/completed.svg";
 import useModalStore from "@/store/useModalStore";
+import { set } from "react-hook-form";
 
 const ProcessNav = ({
   userInfo,
@@ -30,6 +31,12 @@ const ProcessNav = ({
   const handleToggle = () => {
     setIsToggle((prev) => !prev);
   };
+
+  useEffect(() => {
+    const latestUndoneProcess = processes.find((process) => !process.done);
+    const latestUndoneStep = latestUndoneProcess?.step;
+    setCurrentProcess(latestUndoneStep || 1);
+  }, [processes]);
 
   // 프로세스 완료 시 진행
   // const updateProcessCompleted = useMutation(({ storage }, step: number) => {

--- a/src/components/Layout/ProcessNav/index.tsx
+++ b/src/components/Layout/ProcessNav/index.tsx
@@ -14,7 +14,6 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import CompleteIcon from "~/public/completed.svg";
 import useModalStore from "@/store/useModalStore";
-import { set } from "react-hook-form";
 
 const ProcessNav = ({
   userInfo,

--- a/src/components/Modals/SyncModal.tsx
+++ b/src/components/Modals/SyncModal.tsx
@@ -1,9 +1,14 @@
 import { useStorage, useMutation } from "~/liveblocks.config";
 import useModalStore from "@/store/useModalStore";
 import { Process } from "@/lib/types";
-import { set } from "react-hook-form";
+import { SetStateAction, useState } from "react";
+import { Camera } from "@/lib/types";
 
-const SyncedModal = () => {
+interface ModalProps {
+  setCamera: React.Dispatch<SetStateAction<Camera>>;
+}
+
+const SyncedModal = ({ setCamera }: ModalProps) => {
   const { setModalState } = useModalStore();
 
   const process = useStorage((root) => root.process);
@@ -12,6 +17,15 @@ const SyncedModal = () => {
     (process) => !process.done,
   ) as Process;
   const latestUndoneStep = latestUndoneProcess?.step;
+
+  const handleClick = () => {
+    setModalState(false);
+    setCamera(() => ({
+      x: latestUndoneProcess.camera.x,
+      y: latestUndoneProcess.camera.y,
+    }));
+    console.log("hey");
+  };
 
   return (
     <div className=" space-around flex h-[20rem] w-[60rem] flex-col bg-white">
@@ -22,7 +36,7 @@ const SyncedModal = () => {
       <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[4rem] border p-[8px]">
         <button
           className="w-[80px] cursor-pointer rounded-2xl bg-gray-700  p-2 text-center text-[18px] text-white"
-          onClick={() => setModalState(false)}
+          onClick={handleClick}
         >
           닫기
         </button>

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -8,10 +8,15 @@ import CompleteModal from "./CompleteModal";
 import CreateProjectModal from "./CreateProjectModal";
 import ProcessingScenarioModal from "./ProcessingScenarioModal";
 import SyncedModal from "./SyncModal";
-import { useState } from "react";
+import { SetStateAction, useState } from "react";
+import { Camera } from "@/lib/types";
 
 interface ModalMapType {
-  [key: string]: () => JSX.Element;
+  [key: string]: (props?: any) => JSX.Element;
+}
+
+interface ModalProps {
+  setCamera: React.Dispatch<SetStateAction<Camera>>;
 }
 
 const ModalMap: ModalMapType = {
@@ -24,7 +29,7 @@ const ModalMap: ModalMapType = {
   synced: SyncedModal,
 };
 
-const Modal = () => {
+const Modal = ({ setCamera }: ModalProps) => {
   const [isMouseDownInside, setIsMouseDownInside] = useState(false);
   const { isModalOpen, modalType, setModalState } = useModalStore();
 
@@ -37,12 +42,15 @@ const Modal = () => {
   };
 
   const handleMouseUp = (e: React.MouseEvent) => {
-    if (!isMouseDownInside && e.target === e.currentTarget) {
+    const nonClosableModals = ["synced", "processingScenario", "skip"];
+    if (
+      !isMouseDownInside &&
+      e.target === e.currentTarget &&
+      !nonClosableModals.includes(modalType)
+    ) {
       setModalState(false);
     }
-    setIsMouseDownInside(false);
   };
-
   const ModalComponent = ModalMap[modalType];
 
   return (
@@ -53,7 +61,11 @@ const Modal = () => {
           onMouseUp={handleMouseUp}
         >
           <div onClick={stopPropagation} onMouseDown={handleMouseDown}>
-            <ModalComponent />
+            {modalType === "synced" ? (
+              <ModalComponent setCamera={setCamera} />
+            ) : (
+              <ModalComponent />
+            )}
           </div>
         </div>
       )}

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -16,7 +16,7 @@ interface ModalMapType {
 }
 
 interface ModalProps {
-  setCamera: React.Dispatch<SetStateAction<Camera>>;
+  setCamera?: React.Dispatch<SetStateAction<Camera>>;
 }
 
 const ModalMap: ModalMapType = {

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -66,7 +66,6 @@ const Room = ({ roomId }: RoomProps) => {
       <ClientSideSuspense fallback={<Loading />}>
         {() => <Canvas />}
       </ClientSideSuspense>
-      <Modal />
     </RoomProvider>
   );
 };


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close) #102 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 💻 작업 내용

> Sync 버튼 클릭 시 다음 단계로 카메라가 넘어가도록 작업하였습니다. 어떤 액션을 통해 어떻게 사용자들의 Camera를 옮길 것인가 고민하다 결국 처음에 생각한 대로 Modal에 SetCamera옵션을 달되 Sync모달에서 '닫기' 버튼을 눌러야만 닫히며 다음 단계로 넘어가도록 구현하였습니다. 
이벤트 전파를 통한 모달 외부 액션시 닫는 로직을 처리하려니 CreateProjectModal등은 RoomProvider에 속하지 않았기 때문입니다.

Skip과 Vote도 처리해야하는데, setCamera 함수를 모달로 넘기는 과정에서 props로 전달되는 
ModalMapType 내부의 props타입을 뭘로 설정해야 할지 도저히 감이 안잡혀서  any로 설정해두고 조언을 받으려고 우선 PR을 올렸습니다. 이 부분이 해결되면 차례로 skip모달과 vote모달이 닫힐 때에도 단계 업데이트를 처리할 수 있을 것 같네요.

그리고 setCamera액션만 세팅하니 processBar에서 단계 선택된 단계와 표시되는 문구는 수정되지 않아 이 부분도 반영하기 위해 processBar에서도 lastUndoneProcess를 받을 수 있도록 로직을 작성해 변경이 반영되게 구현했습니다.  

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

본문에 말씀드린 Modal/indext.tsx 내부의 ModalMapType에서 any부분 한번 봐주시면 감사하겠습니다
