### PR TITLE
[#124] Fix: 대시보드 새로고침 개선

### DIFF
--- a/src/components/Modals/CreateProjectModal.tsx
+++ b/src/components/Modals/CreateProjectModal.tsx
@@ -34,7 +34,7 @@ const CreateProjectModal = () => {
       method: "POST",
     });
 
-    router.refresh();
+    window.location.reload();
   };
 
   const onSubmit = async (data: any) => {

--- a/src/components/ProjectDetailBox.tsx
+++ b/src/components/ProjectDetailBox.tsx
@@ -26,6 +26,7 @@ const ProjectDetailBox = ({ project }: { project: ProjectInfo }) => {
       onClick: () => {
         if (!authToken) return console.error("authToken does not exist");
         deleteProject(authToken, project.id);
+        window.location.reload();
       },
     },
   ];


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close #124 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] CreateProjectModal 내 router.refresh -> window.location.reload()로 변경

기존 CreateProjectModal내에서 revalidatUserInfo를 통해 userInfo태그가 달린 백엔드로의 요청을 재검증하고, router.refresh를 수행하는 방식으로 새로고침 처리를 하고자 하였습니다. 
예상되는 동작은 백엔드로의 요청을 통한 유저정보 재검증 -> router.refresh()를 통한 새로고침 -> 대시보드 내 프로젝트 컴포넌트 변경 이었지만 새로고침 자체가 이루어지지 않고있었습니다.

https://github.com/vercel/next.js/discussions/62146 에서 동일한 이슈를 발견할 수 있었고,

답변에 달린 https://nextjs.org/docs/app/api-reference/functions/use-router#userouter 공식 문서를 통해 
>router.refresh(): Refresh the current route. Making a new request to the server, re-fetching data requests, and re-rendering Server Components. The client will merge the updated React Server Component payload without losing unaffected client-side React (e.g. useState) or browser state (e.g. scroll position).

요약하자면 서버컴포넌트를 렌더링하나 클라이언트 측 상태는 변하지 않는다.

https://nextjs.org/docs/app/building-your-application/caching#routerrefresh:
>[router.refresh](https://nextjs.org/docs/app/building-your-application/caching#routerrefresh)
The refresh option of the useRouter hook can be used to manually refresh a route. This completely clears the Router Cache, and makes a new request to the server for the current route. refresh does not affect the Data or Full Route Cache.
The rendered result will be reconciled on the client while preserving React state and browser state.

router.refresh()는 라우터 캐시를 지우고 새로운 요청을 보내지만, 데이터 캐시나 전체 경로 캐시는 영향을 받지 않는다는 말을 해주고 있습니다. (페이지 전환시의 캐시를 모두 지우나 현재 페이지에서 api 호출을 통해 받아온 데이터는 영향을 받지 않는다는 뜻인 것 같습니다)

따라서 useclient를 활용한 컴포넌트에서는 새로고침이 발생하지 않은 것으로 보입니다.

다만 분명히 POST 요청 이후에 revalidateUserInfo를 보내고 있고, 이를 통해 새로운 유저 데이터를 받아와 새로고침을 진행할 방법이 있을것으로 보이나 우선 임시방편으로 window.location.reload()를 사용하였습니다. window.location.reload로 전체 새로고침이기 때문에 더 좋은 방법이 분명 있을텐데 이 부분은 클라이언트 렌더링중인 컴포넌트를 TanstackQuery에서는 refetch옵션을 통해 해결할 수 있는것으로 알고있으나 Next에 이에 대응하는 메소드가 무엇인지 찾지를 못했네요... 
단순히 새로고침이 되지 않은 에러이지만 알아야할 점이 참 많았던 에러 같아 이렇게 PR에 남깁니다.

- [x] ProjectDetailBox내에서 삭제버튼 클릭 시 window.location.reload() 추가
위와 동일한 이유로 window.location.reload로 새로고침을 강제로 시켜주었습니다.
