### PR TITLE
[#132] Fix: 실시간 다중 유저가 각 노드를 동시 편집 할 때 변경 사항이 반영되지 않고 버벅이는 이슈 해결

### DIFF
--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -13,6 +13,7 @@ import {
   Template,
   UserInfo,
   Epic,
+  SerializableNode,
 } from "@/lib/types";
 
 const client = createClient({
@@ -70,7 +71,7 @@ type Storage = {
   layerIds: LiveList<string>;
   templates: LiveList<Template>;
   process: LiveList<Process>;
-  nodes: any;
+  nodes: LiveMap<string, LiveObject<SerializableNode>>;
   edges: any;
   voteList: LiveObject<{
     voteCount: LiveObject<{

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,8 @@
-/** @type {import('next').NextConfig} */
+/ @type {import('next').NextConfig} */;
 const nextConfig = {
   webpack: (config) => {
     config.module.rules.push({
-      test: /\.svg$/i,
+      test: /.svg$/i,
       use: ["@svgr/webpack"],
     });
 
@@ -23,7 +23,7 @@ const nextConfig = {
       {
         protocol: "https",
         hostname: "assets.vercel.com",
-        pathname: "/image/upload/**",
+        pathname: "/image/upload/",
       },
       {
         protocol: "https",
@@ -32,6 +32,7 @@ const nextConfig = {
         pathname: "**",
       },
     ],
+    domains: ["syncd-img.s3.ap-northeast-2.amazonaws.com"],
   },
 };
 

--- a/src/components/ReactFlowCanvas/Node/ContentNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/ContentNode.tsx
@@ -1,24 +1,23 @@
+import { SerializableNode } from "@/lib/types";
+import { deserializeNode, serializeNode } from "@/lib/utils";
 import { memo } from "react";
 import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
-import { Handle, Node, Position } from "reactflow";
+import { Handle, Node, NodeProps, Position } from "reactflow";
 import { useMutation, useStorage } from "~/liveblocks.config";
 
-const ContentNode = ({ id, data }: { id: string; data: Node["data"] }) => {
-  const node = useStorage((root) => root.nodes).find(
-    (node: Node) => node.id === id,
+const ContentNode = ({ id, data }: NodeProps) => {
+  const node = deserializeNode(
+    useStorage((root) => root.nodes).get(id) as SerializableNode,
   );
-
-  const forceNodeChange = useMutation(({ storage }) => {
-    storage.set("nodes", [...storage.get("nodes")]);
-  }, []);
 
   const onChangeNodeValue = useMutation(
     ({ storage }, nodeId: string, newLabel: string) => {
-      const node = storage
-        .get("nodes")
-        .find((node: Node) => node.id === nodeId);
-      node.data.label = newLabel;
-      forceNodeChange(); // 작성 중에도 실시간 업데이트
+      const currentNode = storage.get("nodes").get(nodeId);
+      if (currentNode) {
+        currentNode.update({
+          label: newLabel,
+        });
+      }
     },
     [],
   );

--- a/src/components/ReactFlowCanvas/Node/ContentNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/ContentNode.tsx
@@ -15,19 +15,23 @@ const ContentNode = ({ id, data }: NodeProps) => {
       const currentNode = storage.get("nodes").get(nodeId);
       if (currentNode) {
         currentNode.update({
-          label: newLabel,
+          id: nodeId,
+          data: {
+            label: newLabel,
+          },
         });
       }
     },
     [],
   );
+
   const handleLabelChange = (e: ContentEditableEvent) => {
     const newLabel = e.target.value;
     onChangeNodeValue(id, newLabel);
   };
 
   return (
-    <div>
+    <div className="relative flex h-[4.8rem] min-w-[12.8rem] items-center justify-center rounded-[1.2rem] border-[0.1rem] bg-light-gray-100 p-[1rem] scrollbar-hide">
       <Handle
         position={Position.Left}
         className="invisible"
@@ -35,7 +39,7 @@ const ContentNode = ({ id, data }: NodeProps) => {
         type="target"
       />
       <ContentEditable
-        className="pointer-events-auto flex h-[4.8rem] w-[12.8rem] items-center justify-center rounded-[1.2rem] bg-light-gray-100 p-[1rem] text-[1.4rem] font-normal text-div-text outline-none"
+        className="pointer-events-auto flex w-full items-center justify-start p-[1rem]  pl-[2.5rem] text-[1.4rem] font-normal text-div-text outline-none"
         html={node?.data?.label || ""}
         style={{ color: data.color }}
         onChange={handleLabelChange}

--- a/src/components/ReactFlowCanvas/Node/MiddleNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/MiddleNode.tsx
@@ -2,10 +2,10 @@ import { SerializableNode } from "@/lib/types";
 import { deserializeNode } from "@/lib/utils";
 import React, { memo } from "react";
 import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
-import { Handle, Node, Position } from "reactflow";
+import { Handle, NodeProps, Position } from "reactflow";
 import { useMutation, useStorage } from "~/liveblocks.config";
 
-const MiddleNode = ({ id, data }: { id: string; data: any }) => {
+const MiddleNode = ({ id, data }: NodeProps) => {
   const node = deserializeNode(
     useStorage((root) => root.nodes).get(id) as SerializableNode,
   );
@@ -15,7 +15,11 @@ const MiddleNode = ({ id, data }: { id: string; data: any }) => {
       const currentNode = storage.get("nodes").get(nodeId);
       if (currentNode) {
         currentNode.update({
-          label: newLabel,
+          id: nodeId,
+          data: {
+            label: newLabel,
+            color: currentNode.toObject().data.color,
+          },
         });
       }
     },

--- a/src/components/ReactFlowCanvas/Node/MiddleNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/MiddleNode.tsx
@@ -1,24 +1,23 @@
+import { SerializableNode } from "@/lib/types";
+import { deserializeNode } from "@/lib/utils";
 import React, { memo } from "react";
 import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
 import { Handle, Node, Position } from "reactflow";
 import { useMutation, useStorage } from "~/liveblocks.config";
 
 const MiddleNode = ({ id, data }: { id: string; data: any }) => {
-  const label = useStorage((root) => root.nodes).find(
-    (node: Node) => node.id === id,
-  )?.data.label;
-
-  const forceNodeChange = useMutation(({ storage }) => {
-    storage.set("nodes", [...storage.get("nodes")]);
-  }, []);
+  const node = deserializeNode(
+    useStorage((root) => root.nodes).get(id) as SerializableNode,
+  );
 
   const onChangeNodeValue = useMutation(
     ({ storage }, nodeId: string, newLabel: string) => {
-      const node = storage
-        .get("nodes")
-        .find((node: Node) => node.id === nodeId);
-      node.data.label = newLabel;
-      forceNodeChange(); // 작성 중에도 실시간 업데이트
+      const currentNode = storage.get("nodes").get(nodeId);
+      if (currentNode) {
+        currentNode.update({
+          label: newLabel,
+        });
+      }
     },
     [],
   );
@@ -49,7 +48,7 @@ const MiddleNode = ({ id, data }: { id: string; data: any }) => {
       />
 
       <ContentEditable
-        html={label || ""}
+        html={node.data?.label || ""}
         className="flex w-full items-center justify-center text-[1.2rem] font-normal text-black outline-none"
         onChange={handleLabelChange}
       />

--- a/src/components/ReactFlowCanvas/Node/PageNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/PageNode.tsx
@@ -51,18 +51,15 @@ const PageNode = ({ id, data }: NodeProps) => {
   }
 
   const additionalPageNodeXYPosition: XYPosition = {
-    x: node ? node.position.x + computeX(pageNodeEdges) : 0,
+    x: node ? node.position.x + computeX(pageNodeEdges % 5) : 0,
     y: node ? node.position.y + 200 : 0,
   };
 
   const addNode = useMutation(
     ({ storage }, node: Node) => {
       const liveNodes = storage.get("nodes");
-      const nodeId = nanoid();
-
       const newNode = new LiveObject(serializeNode(node));
-      liveNodes.set(nodeId, newNode as LiveObject<SerializableNode>);
-      storage.set;
+      liveNodes.set(node.id, newNode as LiveObject<SerializableNode>);
     },
     [nodes],
   );
@@ -72,7 +69,10 @@ const PageNode = ({ id, data }: NodeProps) => {
       const currentNode = storage.get("nodes").get(nodeId);
       if (currentNode) {
         currentNode.update({
-          label: newLabel,
+          id: nodeId,
+          data: {
+            label: newLabel,
+          },
         });
       }
     },
@@ -155,7 +155,7 @@ const PageNode = ({ id, data }: NodeProps) => {
   );
 
   return (
-    <>
+    <div className="relative flex h-[4.8rem] min-w-[12.8rem] items-center justify-center rounded-[1.2rem] border-[0.1rem] bg-primary p-[1rem] scrollbar-hide">
       <Handle position={Position.Right} className="invisible" type="source" />
       <Handle
         position={Position.Bottom}
@@ -182,7 +182,7 @@ const PageNode = ({ id, data }: NodeProps) => {
         </button>
       </NodeToolbar>
       <ContentEditable
-        className="pointer-events-auto flex h-[4.8rem] w-[12.8rem]  items-center justify-center rounded-[1.2rem] bg-primary p-[1rem] text-[1.4rem] font-semibold text-white outline-none"
+        className="pointer-events-auto flex h-[4.8rem] w-full items-center justify-start pl-[2.5rem] text-[1.4rem] font-semibold text-white outline-none"
         html={node?.data?.label || ""}
         style={{ color: data.color }}
         onChange={handleLabelChange}
@@ -190,7 +190,7 @@ const PageNode = ({ id, data }: NodeProps) => {
       <div className="absolute left-[1rem] top-[1rem] flex items-center gap-[0.8rem]">
         <span className="dragHandle h-[1.25rem] w-[1.25rem] rounded-full bg-white" />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/ReactFlowCanvas/Node/StakeholderNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/StakeholderNode.tsx
@@ -2,12 +2,12 @@ import { SerializableNode } from "@/lib/types";
 import { deserializeNode } from "@/lib/utils";
 import React, { memo } from "react";
 import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
-import { Handle, Node, Position, useStore } from "reactflow";
+import { Handle, NodeProps, Position, useStore } from "reactflow";
 import { useMutation, useStorage } from "~/liveblocks.config";
 
 const connectionNodeIdSelector = (state: any) => state.connectionNodeId;
 
-const StakeholderNode = ({ id, data }: { id: string; data: any }) => {
+const StakeholderNode = ({ id, data }: NodeProps) => {
   const connectionNodeId = useStore(connectionNodeIdSelector);
   const node = deserializeNode(
     useStorage((root) => root.nodes).get(id) as SerializableNode,
@@ -16,7 +16,6 @@ const StakeholderNode = ({ id, data }: { id: string; data: any }) => {
   const onChangeNodeValue = useMutation(
     ({ storage }, nodeId: string, newLabel: string) => {
       const currentNode = storage.get("nodes").get(nodeId);
-      console.log(newLabel, currentNode);
       if (currentNode) {
         currentNode.update({
           id: nodeId,

--- a/src/components/ReactFlowCanvas/index.tsx
+++ b/src/components/ReactFlowCanvas/index.tsx
@@ -34,7 +34,7 @@ import PageNode from "./Node/PageNode";
 import ContentNode from "./Node/ContentNode";
 import AreaNode from "./Node/AreaNode";
 import { LiveObject } from "@liveblocks/client";
-import { serializeNode } from "@/lib/utils";
+import { deserializeNode, serializeNode } from "@/lib/utils";
 import { SerializableNode } from "@/lib/types";
 import useNodes from "@/lib/useNodes";
 
@@ -94,9 +94,7 @@ const Flow = ({ currentProcess }: { currentProcess: number }) => {
   const addNode = useMutation(
     ({ storage }, node: Node) => {
       const liveNodes = storage.get("nodes");
-
       const nodeId = nanoid();
-
       const newNode = new LiveObject(serializeNode(node));
       liveNodes.set(nodeId, newNode as LiveObject<SerializableNode>);
     },
@@ -251,7 +249,7 @@ const Flow = ({ currentProcess }: { currentProcess: number }) => {
 
       // changedNodes를 liveNodeMap에 업데이트
       changedNodes.forEach((node) => {
-        liveNodeMap.set(node.id, new LiveObject(serializeNode(node)));
+        liveNodeMap.get(node.id)?.update(serializeNode(node));
       });
     },
     [nodes],

--- a/src/components/ReactFlowCanvas/index.tsx
+++ b/src/components/ReactFlowCanvas/index.tsx
@@ -37,7 +37,11 @@ import { LiveObject } from "@liveblocks/client";
 import { serializeNode } from "@/lib/utils";
 import { SerializableNode } from "@/lib/types";
 import useNodes from "@/lib/useNodes";
-import { isNodePositionChanges, isNodeRemoveChanges } from "@/lib/guard";
+import {
+  isNodeDimensionChanges,
+  isNodePositionChanges,
+  isNodeRemoveChanges,
+} from "@/lib/guard";
 
 type Viewport = { x: number; y: number; zoom: number };
 
@@ -239,7 +243,7 @@ const Flow = ({ currentProcess }: { currentProcess: number }) => {
       const liveNodeMap = storage.get("nodes");
 
       // 유발한 Node의 변경이 전부 position일 때 (이동만 발생했을 때)
-      if (isNodePositionChanges(changes)) {
+      if (isNodePositionChanges(changes) || isNodeDimensionChanges(changes)) {
         const changedNodes = applyNodeChanges(changes, nodes);
         changedNodes.forEach((node) => {
           storage.get("nodes").get(node.id)?.update(serializeNode(node));

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -3,13 +3,11 @@
 import { RoomProvider } from "~/liveblocks.config";
 import { ClientSideSuspense } from "@liveblocks/react";
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
-import { Layer, Template, Epic } from "@/lib/types";
+import { Layer, Template, Epic, SerializableNode } from "@/lib/types";
 import { Loading } from "./Loading";
 import Canvas from "./Canvas";
 import { steps } from "@/lib/static-data";
 import { syncTemplates } from "@/lib/templates";
-import Modal from "./Modals";
-import nodes from "@/lib/nodes";
 
 interface RoomProps {
   roomId: string;
@@ -46,7 +44,7 @@ const Room = ({ roomId }: RoomProps) => {
         }),
         process: new LiveList(steps),
         templates: new LiveList<Template>(syncTemplates),
-        nodes: nodes,
+        nodes: new LiveMap<string, LiveObject<SerializableNode>>(),
         edges: [],
         voteList: new LiveObject({
           voteCount: new LiveObject({

--- a/src/lib/guard.ts
+++ b/src/lib/guard.ts
@@ -1,0 +1,13 @@
+import { NodeChange, NodePositionChange, NodeRemoveChange } from "reactflow";
+
+export const isNodeRemoveChanges = (
+  changes: NodeChange[],
+): changes is NodeRemoveChange[] => {
+  return changes.every((change) => change.type === "remove");
+};
+
+export const isNodePositionChanges = (
+  changes: NodeChange[],
+): changes is NodePositionChange[] => {
+  return changes.every((change) => change.type === "position");
+};

--- a/src/lib/guard.ts
+++ b/src/lib/guard.ts
@@ -1,4 +1,9 @@
-import { NodeChange, NodePositionChange, NodeRemoveChange } from "reactflow";
+import {
+  NodeChange,
+  NodeDimensionChange,
+  NodePositionChange,
+  NodeRemoveChange,
+} from "reactflow";
 
 export const isNodeRemoveChanges = (
   changes: NodeChange[],
@@ -10,4 +15,10 @@ export const isNodePositionChanges = (
   changes: NodeChange[],
 ): changes is NodePositionChange[] => {
   return changes.every((change) => change.type === "position");
+};
+
+export const isNodeDimensionChanges = (
+  changes: NodeChange[],
+): changes is NodeDimensionChange[] => {
+  return changes.every((change) => change.type === "dimensions");
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,11 @@
+import { LsonObject } from "@liveblocks/client";
+import {
+  CoordinateExtent,
+  EdgeUpdatable,
+  NodeHandleBounds,
+  Position,
+} from "reactflow";
+
 export type NavListType = {
   title: string;
   href: string;
@@ -337,4 +345,40 @@ export type Epic = {
   id: string;
   name: string;
   userStories: UserStory[];
+};
+
+// LsonObject를 확장한 SerializableNode 타입 정의
+export type SerializableNode = LsonObject & {
+  id: string;
+  position: { x: number; y: number };
+  data: any;
+  type?: string;
+  style?: string;
+  className?: string;
+  sourcePosition?: Position;
+  targetPosition?: Position;
+  hidden?: boolean;
+  selected?: boolean;
+  dragging?: boolean;
+  draggable?: boolean;
+  selectable?: boolean;
+  connectable?: boolean;
+  deletable?: boolean;
+  dragHandle?: string;
+  width?: number | null;
+  height?: number | null;
+  parentNode?: string;
+  parentId?: string;
+  zIndex?: number;
+  extent?: "parent" | CoordinateExtent;
+  expandParent?: boolean;
+  positionAbsolute?: { x: number; y: number };
+  ariaLabel?: string;
+  focusable?: boolean;
+  resizing?: boolean;
+  internalsSymbol?: {
+    z?: number;
+    handleBounds?: NodeHandleBounds;
+    isParent?: boolean;
+  };
 };

--- a/src/lib/useNodes.ts
+++ b/src/lib/useNodes.ts
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+import { useStorage } from "~/liveblocks.config";
+import { deserializeNode } from "@/lib/utils";
+import { SerializableNode } from "./types";
+
+// useStorage 훅을 사용하여 노드를 가져오고 캐싱
+const useNodes = () => {
+  const rawNodes = useStorage((root) => root.nodes);
+  return useMemo(() => {
+    return Array.from(rawNodes.values()).map((node) =>
+      deserializeNode(node as SerializableNode),
+    );
+  }, [rawNodes, rawNodes.size]);
+};
+
+export default useNodes;

--- a/src/lib/useNodes.ts
+++ b/src/lib/useNodes.ts
@@ -10,7 +10,7 @@ const useNodes = () => {
     return Array.from(rawNodes.values()).map((node) =>
       deserializeNode(node as SerializableNode),
     );
-  }, [rawNodes, rawNodes.size]);
+  }, [rawNodes]);
 };
 
 export default useNodes;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,8 +9,10 @@ import {
   XYWH,
   PathLayer,
   Camera,
+  SerializableNode,
 } from "./types";
 import { twMerge } from "tailwind-merge";
+import { Node } from "reactflow";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -232,4 +234,38 @@ export const formatTimeToMinSec = (seconds: number): [string, string] => {
     `${remainingSeconds < 10 ? "0" : ""}${minutes}`,
     `${remainingSeconds < 10 ? "0" : ""}${remainingSeconds}`,
   ];
+};
+
+// Node를 SerializableNode로 변환하는 함수
+export const serializeNode = (node: Node): SerializableNode => {
+  return {
+    ...node,
+    style: JSON.stringify(node.style), // CSSProperties를 문자열로 변환
+    position: { x: node.position.x, y: node.position.y },
+    positionAbsolute: node.positionAbsolute
+      ? { x: node.positionAbsolute.x, y: node.positionAbsolute.y }
+      : undefined,
+    sourcePosition: node.sourcePosition,
+    targetPosition: node.targetPosition,
+  };
+};
+
+// SerializableNode를 Node로 변환하는 함수
+export const deserializeNode = (serializableNode: SerializableNode): Node => {
+  return {
+    ...serializableNode,
+    style: serializableNode?.style
+      ? JSON.parse(serializableNode.style)
+      : undefined,
+    position: {
+      x: serializableNode?.position.x,
+      y: serializableNode?.position.y,
+    },
+    positionAbsolute: serializableNode?.positionAbsolute
+      ? {
+          x: serializableNode.positionAbsolute.x,
+          y: serializableNode.positionAbsolute.y,
+        }
+      : undefined,
+  };
 };


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close #132 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 버그 수정

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

실시간으로 다수의 유저가 여러 노드를 수정할 경우 각 어느 노드의 수정 사항도 깔끔하게 반영되지 않고, 버벅이는 이슈를 해결하였습니다.

- [x] liveblocks에서 저장하는 Nodes의 타입 변경 (`any` ->  `LiveMap<string, LiveObject<SerializableNode>>`)
- [x] `Node` 타입을 직렬화하고 `LsonObject` 타입을 교차(`&`)한 `SerializedNode` 타입 추가
- [x] `Node` <-> `SerializedNode` 사이를 변환하는 `serialized()`, `deserialized()` 유틸함수 추가
- [x] Nodes의 타입이 `LiveMap`으로 변경됨에 따라 모든 노드에 대해 노드 추가, 수정 로직 변경
- [x] 노드의 수정 이벤트의 타입에 따른 커스텀 타입 가드 함수 `isNodeRemoveChanges()`, `isNodePositionChanges()` 함수 구현
- [x] **노드의 수정 이벤트(이동, 삭제, 텍스트 추가에 따른 리사이징)에 따라, 변경되는 노드에 대해서만 liveblock 서버에 뮤테이션 요청**

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
