### PR TITLE
[#155] Feat: 3차 QA 이슈 해결 (링크 첨부)

### DIFF
--- a/src/components/Canvas/ColorPicker.tsx
+++ b/src/components/Canvas/ColorPicker.tsx
@@ -7,7 +7,8 @@ type Props = {
 
 export default function ColorPicker({ onChange }: Props) {
   return (
-    <div className="mr-2 flex max-w-[121px] flex-wrap items-center border-r border-divider pr-2">
+    <div className="mr-2 flex max-w-[10rem] flex-wrap items-center border-r border-divider pr-2">
+      <ColorButton color={{ r: 255, g: 255, b: 255 }} onClick={onChange} />
       <ColorButton color={{ r: 229, g: 115, b: 115 }} onClick={onChange} />
       <ColorButton color={{ r: 255, g: 183, b: 77 }} onClick={onChange} />
       <ColorButton color={{ r: 255, g: 241, b: 118 }} onClick={onChange} />
@@ -16,6 +17,7 @@ export default function ColorPicker({ onChange }: Props) {
       <ColorButton color={{ r: 69, g: 106, b: 161 }} onClick={onChange} />
       <ColorButton color={{ r: 186, g: 104, b: 200 }} onClick={onChange} />
       <ColorButton color={{ r: 244, g: 143, b: 177 }} onClick={onChange} />
+      <ColorButton color={{ r: 18, g: 20, b: 23 }} onClick={onChange} />
     </div>
   );
 }

--- a/src/components/CanvasLayer/Sticker.tsx
+++ b/src/components/CanvasLayer/Sticker.tsx
@@ -26,6 +26,12 @@ export default function Sticker({
         strokeWidth={1}
         width={width}
         height={height}
+        style={{
+          userSelect: "none",
+          WebkitUserSelect: "none",
+          MozUserSelect: "none",
+          msUserSelect: "none",
+        }}
       >
         <Image
           draggable={false}

--- a/src/components/CanvasLayer/Text.tsx
+++ b/src/components/CanvasLayer/Text.tsx
@@ -1,7 +1,8 @@
 import ContentEditable, { ContentEditableEvent } from "react-contenteditable";
 import { TextLayer } from "@/lib/types";
-import { cn, colorToCss } from "@/lib/utils";
+
 import { useMutation } from "~/liveblocks.config";
+import { colorToCss } from "@/lib/utils";
 
 interface TextProps {
   id: string;
@@ -10,14 +11,14 @@ interface TextProps {
   selectionColor?: string;
 }
 
-const calculateFontSize = (width: number, height: number) => {
-  const maxFontSize = 96;
-  const scaleFactor = 0.5;
-  const fontSizeBasedOnHeight = height * scaleFactor;
-  const fontSizeBasedOnWidth = width * scaleFactor;
+// const calculateFontSize = (width: number, height: number) => {
+//   const maxFontSize = 96;
+//   const scaleFactor = 0.5;
+//   const fontSizeBasedOnHeight = height * scaleFactor;
+//   const fontSizeBasedOnWidth = width * scaleFactor;
 
-  return Math.min(fontSizeBasedOnHeight, fontSizeBasedOnWidth, maxFontSize);
-};
+//   return Math.min(fontSizeBasedOnHeight, fontSizeBasedOnWidth, maxFontSize);
+// };
 
 const Text = ({ layer, onPointerDown, id, selectionColor }: TextProps) => {
   const { x, y, width, height, fill, value } = layer;
@@ -39,9 +40,6 @@ const Text = ({ layer, onPointerDown, id, selectionColor }: TextProps) => {
       width={width}
       height={height}
       onPointerDown={(e) => onPointerDown(e, id)}
-      style={{
-        outline: selectionColor ? `1px solid ${selectionColor}` : "none",
-      }}
     >
       <ContentEditable
         html={value || " "}
@@ -49,7 +47,7 @@ const Text = ({ layer, onPointerDown, id, selectionColor }: TextProps) => {
         className="flex h-full w-full justify-normal text-center outline-none drop-shadow-md"
         style={{
           fontSize: 14,
-          color: "black",
+          color: colorToCss(fill) || "black",
         }}
       />
     </foreignObject>

--- a/src/components/Common/Carousel.tsx
+++ b/src/components/Common/Carousel.tsx
@@ -206,7 +206,7 @@ const CarouselPrevious = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        "absolute ml-24 h-16 w-16 rounded-full bg-white",
+        "absolute h-16 w-16 translate-x-[-2rem] rounded-full bg-white",
         orientation === "horizontal"
           ? "-left-16 top-1/2 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
@@ -235,7 +235,7 @@ const CarouselNext = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        "absolute mr-24 h-16 w-16 rounded-full bg-white",
+        "absolute h-16 w-16 translate-x-[2rem] rounded-full bg-white",
         orientation === "horizontal"
           ? "-right-16 top-1/2 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",

--- a/src/components/GuideCarousel.tsx
+++ b/src/components/GuideCarousel.tsx
@@ -15,18 +15,15 @@ interface StyledCarouselProps {
 
 const GuideCarousel = ({ exampleList }: StyledCarouselProps) => {
   return (
-    <Carousel className="flex h-full items-center justify-center">
+    <Carousel className="mx-[4rem] flex h-full items-center justify-center">
       <CarouselContent className="flex w-full">
         {exampleList.map((example, index) => (
-          <CarouselItem className="flex justify-center" key={index}>
+          <CarouselItem
+            className="flex items-center justify-center"
+            key={index}
+          >
             <div className="flex justify-center">
-              <Image
-                className="flex justify-center"
-                width={700}
-                height={0}
-                src={example.src}
-                alt={`guide`}
-              />
+              <Image width={700} height={0} src={example.src} alt={`guide`} />
             </div>
           </CarouselItem>
         ))}

--- a/src/components/Modals/VoteCompleteModal.tsx
+++ b/src/components/Modals/VoteCompleteModal.tsx
@@ -5,8 +5,10 @@ import {
 } from "~/liveblocks.config";
 import useModalStore from "@/store/useModalStore";
 import { Process } from "@/lib/types";
-import { SetStateAction, useState } from "react";
+import { SetStateAction } from "react";
 import { Camera } from "@/lib/types";
+import Lottie from "react-lottie";
+import checkJson from "~/public/lotties/check.json";
 
 interface ModalProps {
   setCamera: React.Dispatch<SetStateAction<Camera>>;
@@ -64,22 +66,38 @@ const VoteCompleteModal = ({ setCamera }: ModalProps) => {
   };
 
   const { winningVote } = countVoteResult();
+
+  const defaultOptions = {
+    loop: false,
+    autoplay: true,
+    animationData: checkJson,
+    rendererSettings: {
+      preserveAspectRatio: "xMidYMid slice",
+    },
+  };
+
   return (
-    <div className=" space-around flex h-[20rem] w-[60rem] flex-col bg-white">
-      <div className="border-grey-100 flex h-[50px] items-center justify-center border p-[8px]">
-        Synced!
+    <div className="flex h-[fit] w-[40rem] flex-col items-center justify-start gap-[0.8rem] rounded-[2rem] bg-white px-[4.45rem] py-[3.2rem] shadow-2xl">
+      <div className="flex h-[16rem] w-[16rem] items-center justify-center">
+        <Lottie options={defaultOptions} height={200} width={200} />
       </div>
-      <div className="h-full">
-        {winningVote}번이 가장 많은 득표수를 획득하였습니다!
+      <div className="flex flex-col items-center justify-center gap-[0.2rem]">
+        <span className="text-[1.8rem] font-semibold text-div-text">
+          우리 팀은
+        </span>
+        <span className="text-[3.6rem] font-bold text-div-text">
+          {winningVote}번 문제
+        </span>
+        <span className="text-[1.8rem] font-semibold text-div-text">
+          에 가장 관심이 많았어요 !
+        </span>
       </div>
-      <div className="border-grey-100 flex h-[50px] items-center justify-center gap-[4rem] border p-[8px]">
-        <button
-          className="w-[80px] cursor-pointer rounded-2xl bg-gray-700  p-2 text-center text-[18px] text-white"
-          onClick={handleClick}
-        >
-          닫기
-        </button>
-      </div>
+      <button
+        className="mt-[1.6rem] min-w-[7.2rem] cursor-pointer rounded-[1.2rem] bg-gray-700 px-[1.2rem] py-[0.8rem] text-center text-[1.4rem] font-normal text-white"
+        onClick={handleClick}
+      >
+        닫기
+      </button>
     </div>
   );
 };

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -70,19 +70,22 @@ const ProjectCard = ({ project }: { project: ProjectInfo }) => {
             {project.description}
           </p>
           <p className="w-full text-[1.4rem] font-thin text-time">5 members</p>
-          {isDetailBoxOpen && detailBoxPosition && (
-            <div
-              className="fixed z-10"
-              style={{
-                top: `${detailBoxPosition.y}px`,
-                left: `${detailBoxPosition.x}px`,
-              }}
-            >
-              <ProjectDetailBox project={project} />
-            </div>
-          )}
         </div>
       </Link>
+      {isDetailBoxOpen && detailBoxPosition && (
+        <div
+          className="fixed z-10"
+          style={{
+            top: `${detailBoxPosition.y}px`,
+            left: `${detailBoxPosition.x}px`,
+          }}
+        >
+          <ProjectDetailBox
+            project={project}
+            setIsDetailBoxOpen={setIsDetailBoxOpen}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ProjectDetailBox.tsx
+++ b/src/components/ProjectDetailBox.tsx
@@ -5,8 +5,17 @@ import TrashIcon from "~/public/trash.svg";
 import { deleteProject } from "@/lib/data";
 import useGetAuthToken from "@/hooks/useGetAuthToken";
 import { cn } from "@/lib/utils";
+import XMarkIcon from "~/public/Xmark";
 
-const ProjectDetailBox = ({ project }: { project: ProjectInfo }) => {
+type ProjectDetailBoxProps = {
+  project: ProjectInfo;
+  setIsDetailBoxOpen: () => void;
+};
+
+const ProjectDetailBox = ({
+  project,
+  setIsDetailBoxOpen,
+}: ProjectDetailBoxProps) => {
   const authToken = useGetAuthToken();
 
   const Menus: MenuType[] = [
@@ -32,7 +41,7 @@ const ProjectDetailBox = ({ project }: { project: ProjectInfo }) => {
   ];
 
   return (
-    <div className="flex h-[16.8rem] w-[16.4rem] flex-col items-center justify-start rounded-[1.2rem] bg-white shadow-md shadow-light-gray-100">
+    <div className="relative flex h-[16.8rem] w-[16.4rem] flex-col items-center justify-start rounded-[1.2rem] bg-white shadow-md shadow-light-gray-100">
       <div className="flex w-full flex-col items-start justify-center gap-[0.4rem] border-b-[1px] border-light-gray-100 p-[1.6rem]">
         <span className="text-[1.4rem] font-thin text-time">
           role:{" "}
@@ -62,6 +71,12 @@ const ProjectDetailBox = ({ project }: { project: ProjectInfo }) => {
           </div>
         ))}
       </div>
+      <button
+        className="absolute right-6 top-8 cursor-pointer"
+        onClick={() => setIsDetailBoxOpen()}
+      >
+        <XMarkIcon width={18} height={18} fill="lightgray" />
+      </button>
     </div>
   );
 };

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -86,7 +86,7 @@ export default [
   {
     id: "rootNode",
     type: "pageNode",
-    position: { x: 650, y: 1690 },
+    position: { x: 650, y: 2250 },
     data: { label: "메인 페이지" },
     dragHandle: ".dragHandle",
   },
@@ -114,6 +114,6 @@ export default [
         "우리 서비스에는 어떠한 페이지들이 있을까요? \n또 각 페이지들은 어떤 기능들을 가지고 있을까요? \n좌측 상단 도움말을 눌러 예시 이미지를 참고해 여러분 서비스의 Tree를 그려주세요!",
       font: "text-lg",
     },
-    position: { x: 100, y: 1710 },
+    position: { x: 100, y: 2270 },
   },
 ] as Node[];


### PR DESCRIPTION
## #️⃣ 연관 이슈

> close #155 

[QA 링크](https://jjunohj2.notion.site/QA-05f02a363fb14d8996cbb4abb43479e1?pvs=4)

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [x] 버그 수정

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 12단계 메뉴트리 메인 페이지 노드가 9단계에 보이는 이슈 해결
- [x] 9단계 StakeholderNode에서 엣지를 끌어서 캔버스에 놓으면 MiddleNode가 나오는 것 수정
- [x] 안내문 모달 컨텐츠를 화살표가 가리는 이슈 해결
- [x] 프로젝트 세팅, 삭제 누를 경우 프로젝트에 들어가지는 이슈 해결
- [x] 선택 가능한 색깔에 검정색 추가, 위아래 두줄에 색깔 개수 통일
- [x] 투표 취합 모달 리퍼블리싱
- [x] 스티커가 드로잉 중에 드래그 되는 현상 수정

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

<img width="216" alt="스크린샷 2024-06-05 오후 1 44 04" src="https://github.com/i-Dear/sync-d-frontend/assets/121740394/3126368e-6cba-4483-8c5c-49c041bfd463">

> 선택 가능한 색깔에 검정색 추가, 위아래 두줄에 색깔 개수 통일

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
