### PR TITLE
[#171] Feat: 아이패드 관련 QA 적용, 우측 툴바 서랍효과 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import "reactflow/dist/base.css";
 import "reactflow/dist/style.css";
 import type { Metadata, Viewport } from "next";
+import CustomRootLayout from "@/components/Layout/RootLayout";
 import Metrics from "@/metrics";
 
 export const metadata: Metadata = {
@@ -25,7 +26,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <CustomRootLayout>{children}</CustomRootLayout>
       <Metrics />
     </html>
   );

--- a/src/components/CanvasLayer/Epic.tsx
+++ b/src/components/CanvasLayer/Epic.tsx
@@ -57,7 +57,7 @@ export default function Epic({
     prevStory.push({ id: prevStory[prevStory.length - 1].id + 1, name: "" });
     const newStory = prevStory;
     liveLayers.get(id)?.set("value", newStory);
-    const newHeight = newStory.length * 70 + 160;
+    const newHeight = newStory.length * 60 + 150;
     liveLayers.get(id)?.set("height", newHeight);
   }, []);
 
@@ -70,7 +70,7 @@ export default function Epic({
     const prevStory = liveLayers.get(id)?.get("value") as UserStory[];
     const newStory = prevStory.filter((_, i) => i !== index);
     liveLayers.get(id)?.set("value", newStory);
-    const newHeight = newStory.length * 70 + 160;
+    const newHeight = newStory.length * 60 + 150;
     liveLayers.get(id)?.set("height", newHeight);
   }, []);
 
@@ -93,7 +93,7 @@ export default function Epic({
       x={x}
       y={y}
       width={width}
-      height={height === 0 ? length * 70 + 160 : height}
+      height={height === 0 ? length * 60 + 150 : height}
       style={{ background: "#E9F5FF" }}
       onPointerDown={(e) => onPointerDown(e, id)}
       onFocus={handleFocus}
@@ -111,7 +111,7 @@ export default function Epic({
           color: "white",
         }}
       />
-      <div className="my-[2rem] flex flex-col gap-[2rem]">
+      <div className="my-[1rem] flex flex-col gap-[1rem]">
         {value &&
           value.map((item, index) => (
             <div className="relative" key={item.id}>

--- a/src/components/Layout/CollabToolAside/MusicPlayer/index.tsx
+++ b/src/components/Layout/CollabToolAside/MusicPlayer/index.tsx
@@ -274,7 +274,7 @@ export function MusicPlayer() {
                 className="flex h-[32px] w-[32px] items-center justify-center rounded-full bg-primary"
                 onClick={toggleMute}
               >
-                <div className="flex h-[2rem] w-[2rem] items-center justify-center">
+                <div className="flex h-[20px] w-[20px] items-center justify-center">
                   <MuteIcon />
                 </div>
               </div>
@@ -283,7 +283,7 @@ export function MusicPlayer() {
                 className="flex h-[32px] w-[32px] items-center justify-center rounded-full bg-primary"
                 onClick={toggleMute}
               >
-                <div className="flex h-[2rem] w-[2rem] items-center justify-center">
+                <div className="flex h-[20px] w-[20px] items-center justify-center">
                   <MuteOffIcon />
                 </div>
               </div>

--- a/src/components/Layout/CollabToolAside/index.tsx
+++ b/src/components/Layout/CollabToolAside/index.tsx
@@ -1,35 +1,77 @@
-import { memo } from "react";
+import { memo, useState } from "react";
+import { motion } from "framer-motion";
 import LiveAvatars from "./LiveAvatars";
 import Timer from "./Timer";
 import GroupCall from "./GroupCall";
 import { MusicPlayer } from "./MusicPlayer";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { useEventListener } from "~/liveblocks.config";
-import ProgressBar from "./ProgressBar";
 
 type GroupCallProps = {
   roomId: string;
 };
 
 const CollabToolAside = memo(({ roomId }: GroupCallProps) => {
-  useEventListener(({ event }) => {
-    if (event.type === "TIMER_END") {
-      toast("Time's up!", {
-        toastId: 1,
-      });
-    }
-  });
+  const [isToggled, setIsToggled] = useState(false);
+
+  const handleToggle = () => {
+    setIsToggled(!isToggled);
+  };
+
+  const variants = {
+    open: { transform: "translateX(0%)" },
+    closed: { transform: "translateX(100%)" },
+  };
 
   return (
-    <aside className="absolute right-0 z-10 flex h-screen w-[346px] flex-col gap-[16px] bg-white p-[16px] ">
-      <LiveAvatars />
-      <ProgressBar />
-      <Timer />
-      <GroupCall roomId={roomId} />
-      <MusicPlayer />
-      <ToastContainer autoClose={10000} />
-    </aside>
+    <>
+      <motion.aside
+        initial="closed"
+        animate={isToggled ? "open" : "closed"}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="absolute right-0 top-0 z-10 h-screen"
+        style={{ width: "34.6rem" }}
+        variants={variants}
+      >
+        <div className="relative flex h-full flex-col gap-[1.6rem] bg-white p-[1.6rem]">
+          <LiveAvatars />
+          <Timer />
+          <GroupCall roomId={roomId} />
+          <MusicPlayer />
+          <ToastContainer autoClose={10000} />
+        </div>
+        <motion.div
+          className="top-10% right-110% absolute z-10 flex h-[5rem] w-[5rem] cursor-pointer items-center justify-center rounded-full bg-primary shadow-sm"
+          style={{
+            top: "10%",
+            right: "110%",
+          }}
+          onClick={handleToggle}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+        >
+          <svg
+            width="30"
+            height="30"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{
+              // Conditional styling to flip the SVG arrow based on toggle state
+              transform: isToggled ? "scaleX(-1)" : "scaleX(1)",
+            }}
+          >
+            <path
+              d="M15 18L9 12L15 6"
+              stroke="white"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </motion.div>
+      </motion.aside>
+    </>
   );
 });
 

--- a/src/components/Layout/RootLayout.tsx
+++ b/src/components/Layout/RootLayout.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const CustomRootLayout = ({ children }: { children: React.ReactNode }) => {
+  const [vh, setVh] = useState("100vh");
+
+  useEffect(() => {
+    const setVhToWindowHeight = () => {
+      let vh = window.innerHeight * 0.01;
+      setVh(`${vh}px`);
+      document.documentElement.style.setProperty("--vh", `${vh}px`);
+    };
+
+    setVhToWindowHeight();
+    window.addEventListener("resize", setVhToWindowHeight);
+    return () => window.removeEventListener("resize", setVhToWindowHeight);
+  }, []);
+
+  return (
+    <html lang="ko">
+      <body
+        style={{
+          height: `calc(var(--vh, 1vh) * 100)`,
+        }}
+        className="relative mx-auto flex w-screen flex-col items-center"
+      >
+        <main
+          style={{ height: `calc(var(--vh, 1vh) * 100)` }}
+          className="flex flex-col items-center justify-center"
+        >
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+};
+
+export default CustomRootLayout;

--- a/src/components/ReactFlowCanvas/Node/MiddleNode.tsx
+++ b/src/components/ReactFlowCanvas/Node/MiddleNode.tsx
@@ -59,7 +59,7 @@ const MiddleNode = ({ id, data }: NodeProps) => {
 
       <div className="absolute left-[0.5rem] top-[0.5rem] flex items-center gap-[0.8rem]">
         <span
-          className="dragHandle h-[0.75rem] w-[0.75rem] cursor-grab rounded-full"
+          className="dragHandle h-[0.75rem] w-[0.75rem] rounded-full"
           style={{
             background: data.color,
           }}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -283,3 +283,21 @@ export const convertDataUrlToBlob = (dataUrl: string) => {
 
   return new Blob([ab], { type: mimeString });
 };
+
+export const isTouchDevice = () => {
+  return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+};
+
+export const extractPosition = (
+  event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+): {
+  x: number;
+  y: number;
+} => {
+  if ("touches" in event && event.touches.length > 0) {
+    return { x: event.touches[0].clientX, y: event.touches[0].clientY };
+  } else if ("clientX" in event) {
+    return { x: event.clientX, y: event.clientY };
+  }
+  return { x: 0, y: 0 };
+};


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #171 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 모바일 뷰에서 상단 브라우저 검색바만큼 컨텐츠가 잘리던 이슈 해결
- [x] 모바일 기기 내 5, 6, 7 단계에서 노드 엣지를 끌어서 노드 추가가 안되는 이슈 해결
- [x] 모바일 기기에서 노드 그랩안되는 이슈 해결
- [x] AsideToolbar 서랍 서랍 효과 추가로 사용성 개선
- [x] 에픽, 유저스토리 크기 소폭 변경

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

https://github.com/i-Dear/sync-d-frontend/assets/121740394/101c73ed-9e47-4fbb-8973-0c38a6f5b969

https://github.com/i-Dear/sync-d-frontend/assets/121740394/e1eefb63-a637-4b40-8daf-584bccd6c7ae

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

기존에 event 처리 방식이 any로 되어있었는데, event를 터치 환경에서, 마우스 환경에서 한 번씩 시도해보고나니까, `MouseEvent | TouchEvent`로 타입을 고정할 수 있겠다라고 생각을 했습니다. 이후 구글에서 검색해보며 각 이벤트의 `target`을 어떻게 처리해야할지 찾아봤습니다.(도착 target에 따라 구현 로직을 짜야했음) 각 이벤트(터치, 마우스)의 target이 달라 발생하는 문제가 많았었는데, 콘솔창을 까보니까 문제점이 TouchEvent와 ClickEvent에서 드래그할 경우 `target`이 TouchEvent의 경우 시작요소, ClickEvent의 경우 도착요소에 있다는 걸 알게 됐어요. 이를 해결하기 위해 event에서 활용할 수 있는 다른 속성들을 찾아보니까, 커서의 절대좌표를 알아낼 수 있더라구요. 이를 활용해서 해당 절대좌표의 요소를 찾아내는 방식을 통해 구현했습니다 !
